### PR TITLE
Images working on Github PAges

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -146,7 +146,7 @@ section .container {
 .banner {
   height: 28.4375rem;
   position: relative;
-  background: url(/assets/img/header.JPG);
+  background: url (assets/img/header.JPG);
   background-repeat: no-repeat;
   background-size: 100%;
   top: -9rem;

--- a/assets/style.css
+++ b/assets/style.css
@@ -146,7 +146,7 @@ section .container {
 .banner {
   height: 28.4375rem;
   position: relative;
-  background: url (/assets/img/header.JPG);
+  background: url(/assets/img/header.JPG);
   background-repeat: no-repeat;
   background-size: 100%;
   top: -9rem;

--- a/assets/style.css
+++ b/assets/style.css
@@ -146,7 +146,7 @@ section .container {
 .banner {
   height: 28.4375rem;
   position: relative;
-  background: url (assets/img/header.JPG);
+  background: url (/assets/img/header.JPG);
   background-repeat: no-repeat;
   background-size: 100%;
   top: -9rem;

--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link
       rel="stylesheet"
-      href="/bootstrap-5.1.0-dist/bootstrap/css/bootstrap.min.css"
+      href="bootstrap-5.1.0-dist/bootstrap/css/bootstrap.min.css"
     />
-    <link rel="stylesheet" href="/assets/style.css" />
+    <link rel="stylesheet" href="assets/style.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -44,7 +44,7 @@
         </div>
       </div>
       <div class="logo">
-        <img id="logotipo" src="/assets/img/logo.JPG" alt="logotipo" />
+        <img id="logotipo" src="assets/img/logo.JPG" alt="logotipo" />
       </div>
     </header>
 
@@ -242,7 +242,7 @@
       <div id="footer-grid">
         <div class="row">
           <div class="col-sm-3">
-            <img id=logo-2 src="/assets/img/logo.JPG">
+            <img id=logo-2 src="assets/img/logo.JPG">
           </div>
           <div class="col-sm-9">
             <div class="row">
@@ -274,6 +274,6 @@
     </footer>
 
     <script src="bootstrap-5.1.0-dist/bootstrap/js/bootstrap.min.js"></script>
-    <script src="/assets/main.js"></script>
+    <script src="assets/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The '/' to navigate through folders are not necessary in Github Pages and were preventing CSS, JS and assets to load. Test has been made in branch, images now do work. 